### PR TITLE
[BS-387][LB] Fix filter matching for Individual details, Update test endpoints

### DIFF
--- a/app/uk/gov/hmrc/breathingspaceifstub/controller/IndividualController.scala
+++ b/app/uk/gov/hmrc/breathingspaceifstub/controller/IndividualController.scala
@@ -38,7 +38,7 @@ class IndividualController @Inject()(individualService: IndividualService, cc: C
 
   def delete(nino: String): Action[Unit] = Action.async(withoutBody) { implicit request =>
     implicit val requestId = RequestId(BS_Individual_DELETE)
-    individualService.delete(nino).map(_.fold(logAndGenErrorResult, _ => Ok))
+    individualService.delete(nino).map(_.fold(logAndGenErrorResult, _ => NoContent))
   }
 
   val deleteAll: Action[Unit] = Action.async(withoutBody) { implicit request =>
@@ -47,7 +47,7 @@ class IndividualController @Inject()(individualService: IndividualService, cc: C
   }
 
   def exists(nino: String): Action[Unit] = Action.async(withoutBody) { _ =>
-    individualService.exists(nino).map(result => Ok(result.toString))
+    individualService.exists(nino).map(result => Ok(Json.obj("exists" -> result)))
   }
 
   val listOfNinos: Action[Unit] = Action.async(withoutBody) { _ =>
@@ -59,7 +59,7 @@ class IndividualController @Inject()(individualService: IndividualService, cc: C
       implicit val requestId = RequestId(BS_Individual_POST)
       request.body.fold(
         logAndSendErrorResult,
-        individualService.addIndividual(_).map(_.fold(logAndGenErrorResult, _ => Ok))
+        individualService.addIndividual(_).map(_.fold(logAndGenErrorResult, _ => Created))
       )
   }
 
@@ -79,7 +79,7 @@ class IndividualController @Inject()(individualService: IndividualService, cc: C
       implicit val requestId = RequestId(BS_Individual_PUT)
       request.body.fold(
         logAndSendErrorResult,
-        individualService.replaceIndividualDetails(nino, _).map(_.fold(logAndGenErrorResult, _ => Ok))
+        individualService.replaceIndividualDetails(nino, _).map(_.fold(logAndGenErrorResult, _ => NoContent))
       )
     }
 }

--- a/app/uk/gov/hmrc/breathingspaceifstub/model/Failure.scala
+++ b/app/uk/gov/hmrc/breathingspaceifstub/model/Failure.scala
@@ -26,10 +26,10 @@ sealed abstract class BaseError(val httpCode: Int, val message: String) extends 
 object BaseError extends Enum[BaseError] {
 
   case object BAD_GATEWAY extends BaseError(Status.BAD_GATEWAY, "Downstream systems are not responding")
-  case object INVALID_BODY extends BaseError(BAD_REQUEST, "Not expected a body to this endpoint")
   case object CONFLICTING_REQUEST extends BaseError(CONFLICT, "The request is conflicting. Maybe a duplicate POST?")
   case object HEADERS_PRECONDITION_NOT_MET extends BaseError(PRECONDITION_REQUIRED, "Invalid header combination")
   case object IDENTIFIER_NOT_FOUND extends BaseError(NOT_FOUND, "The provided identifier cannot be found")
+  case object INVALID_BODY extends BaseError(BAD_REQUEST, "Not expected a body to this endpoint")
   case object INVALID_ENDPOINT extends BaseError(BAD_REQUEST, "Not a valid endpoint")
   case object INVALID_FIELDS extends BaseError(BAD_REQUEST, "Invalid query parameter(fields)")
   case object INVALID_IDENTIFIERS extends BaseError(PRECONDITION_REQUIRED, "Invalid path parameter combination")
@@ -37,6 +37,9 @@ object BaseError extends Enum[BaseError] {
   case object INVALID_NINO extends BaseError(BAD_REQUEST, "Invalid Nino")
   case object MISSING_BODY extends BaseError(BAD_REQUEST, "The request must have a body")
   case object MISSING_JSON_HEADER extends BaseError(UNSUPPORTED_MEDIA_TYPE, "'Content-Type' header missing or invalid")
+
+  // Only used by test-only endpoints. IDENTIFIER_NOT_FOUND is returned by EIS.
+  case object RESOURCE_NOT_FOUND extends BaseError(NOT_FOUND, "The provided identifier cannot be found")
 
   case object SERVER_ERROR
       extends BaseError(
@@ -51,7 +54,7 @@ object BaseError extends Enum[BaseError] {
 
   // Must only be used by the ErrorCodeController.
   // The NOT_IMPLEMENTED Http status code was chosen because it's not used by any other BaseError instance.
-  case object UNKNOWN_ERROR_CODE extends BaseError(NOT_IMPLEMENTED, "Unknown requested error code")
+  case object UNKNOWN_ERROR_CODE extends BaseError(NOT_IMPLEMENTED, "The error code identifier requested is unknown")
 
   override val values = findValues
 }

--- a/app/uk/gov/hmrc/breathingspaceifstub/model/IndividualDetails.scala
+++ b/app/uk/gov/hmrc/breathingspaceifstub/model/IndividualDetails.scala
@@ -18,7 +18,6 @@ package uk.gov.hmrc.breathingspaceifstub.model
 
 import java.time.LocalDate
 
-import cats.syntax.option._
 import play.api.libs.json.Json
 
 // --------------------------------------------------------------------------------
@@ -40,9 +39,9 @@ object NameList { implicit val format = Json.format[NameList] }
 // --------------------------------------------------------------------------------
 
 final case class IndividualDetails(
-  dateOfBirth: Option[LocalDate] = none,
-  crnIndicator: Option[Int] = none,
-  nameList: Option[NameList] = none
+  dateOfBirth: Option[LocalDate],
+  crnIndicator: Option[Int],
+  nameList: Option[NameList]
 )
 
 object IndividualDetails { implicit val format = Json.format[IndividualDetails] }

--- a/app/uk/gov/hmrc/breathingspaceifstub/schema/IndividualDetails.scala
+++ b/app/uk/gov/hmrc/breathingspaceifstub/schema/IndividualDetails.scala
@@ -31,7 +31,7 @@ final case class IndividualDetail0(
   crnIndicator: Option[Int]
 )
 object IndividualDetail0 {
-  val fields = "?fields=details(nino,dateOfBirth,cnrIndicator)"
+  val fields = "details(nino,dateOfBirth,cnrIndicator)"
 
   implicit val writes = Json.writes[IndividualDetail0]
 
@@ -49,7 +49,7 @@ final case class IndividualDetail1(
   nameList: Option[model.NameList]
 )
 object IndividualDetail1 {
-  val fields = "?fields=details(nino,dateOfBirth),namelist(name(firstForename,secondForename,surname))"
+  val fields = "details(nino,dateOfBirth),namelist(name(firstForename,secondForename,surname))"
 
   implicit val writes = Json.writes[IndividualDetail1]
 

--- a/it/uk/gov/hmrc/breathingspaceifstub/controller/IndividualControllerISpec.scala
+++ b/it/uk/gov/hmrc/breathingspaceifstub/controller/IndividualControllerISpec.scala
@@ -23,9 +23,9 @@ class IndividualControllerISpec extends BaseISpec {
 
   test("\"delete(nino)\" should wipe out the \"individual\" document for the given Nino") {
     val individual = genIndividualInRequest()
-    status(postIndividual(individual)) shouldBe OK
-    contentAsString(exists(individual.nino)) shouldBe "true"
-    status(delete(individual.nino)) shouldBe OK
+    status(postIndividual(individual)) shouldBe CREATED
+    contentAsString(exists(individual.nino)) shouldBe """{"exists":true}"""
+    status(delete(individual.nino)) shouldBe NO_CONTENT
 
     val response = count
     status(response) shouldBe OK
@@ -45,10 +45,10 @@ class IndividualControllerISpec extends BaseISpec {
 
   test("\"exists(nino)\" should confirm if the \"individual\" collection contains or not the given Nino") {
     val individual = genIndividualInRequest()
-    status(postIndividual(individual)) shouldBe OK
-    contentAsString(exists(individual.nino)) shouldBe "true"
+    status(postIndividual(individual)) shouldBe CREATED
+    contentAsString(exists(individual.nino)) shouldBe """{"exists":true}"""
 
-    contentAsString(exists(genNino)) shouldBe "false"
+    contentAsString(exists(genNino)) shouldBe """{"exists":false}"""
   }
 
   test("\"listOfNinos\" should return the list of all Ninos in the \"individual\" collection") {
@@ -63,14 +63,14 @@ class IndividualControllerISpec extends BaseISpec {
 
   test("\"postIndividual\" should successfully add a new document to the \"individual\" collection") {
     val individual = genIndividualInRequest()
-    status(postIndividual(individual)) shouldBe OK
-    contentAsString(exists(individual.nino)) shouldBe "true"
+    status(postIndividual(individual)) shouldBe CREATED
+    contentAsString(exists(individual.nino)) shouldBe """{"exists":true}"""
   }
 
   test("\"postIndividual\" should return 409(CONFLICT) when adding an existing Nino to the \"individual\" collection") {
     val individual = genIndividualInRequest()
-    status(postIndividual(individual)) shouldBe OK
-    contentAsString(exists(individual.nino)) shouldBe "true"
+    status(postIndividual(individual)) shouldBe CREATED
+    contentAsString(exists(individual.nino)) shouldBe """{"exists":true}"""
 
     val response = postIndividual(individual)
     status(response) shouldBe CONFLICT
@@ -104,18 +104,19 @@ class IndividualControllerISpec extends BaseISpec {
 
     val individualDetails = IndividualDetails(
       dateOfBirth = LocalDate.now.some,
+      crnIndicator = none,
       nameList = NameList(List(NameData(firstForename = "Joe".some, surname = "Zawinul".some, none))).some
     )
     val response = replaceIndividualDetails(individual2.nino, individualDetails)
-    status(response) shouldBe OK
+    status(response) shouldBe NO_CONTENT
   }
 
   test("\"replaceIndividualDetails\" should return 404(NOT_FOUND) when trying to update an unknown Nino") {
     val individual = genIndividualInRequest()
-    status(postIndividual(individual)) shouldBe OK
-    contentAsString(exists(individual.nino)) shouldBe "true"
+    status(postIndividual(individual)) shouldBe CREATED
+    contentAsString(exists(individual.nino)) shouldBe """{"exists":true}"""
 
-    val individualDetails = IndividualDetails(dateOfBirth = LocalDate.now.some)
+    val individualDetails = IndividualDetails(dateOfBirth = LocalDate.now.some, none, none)
     val response = replaceIndividualDetails(genNino, individualDetails)
     status(response) shouldBe NOT_FOUND
   }

--- a/it/uk/gov/hmrc/breathingspaceifstub/controller/IndividualDetailsControllerISpec.scala
+++ b/it/uk/gov/hmrc/breathingspaceifstub/controller/IndividualDetailsControllerISpec.scala
@@ -13,8 +13,8 @@ class IndividualDetailsControllerISpec extends BaseISpec {
 
   test("\"get\" with query parameter \"fields\" equal to detail #0)") {
     val dateOfBirth = LocalDate.now
-    val individual = genIndividualInRequest(IndividualDetails(dateOfBirth.some).some)
-    status(postIndividual(individual)) shouldBe OK
+    val individual = genIndividualInRequest(IndividualDetails(dateOfBirth.some, none, none).some)
+    status(postIndividual(individual)) shouldBe CREATED
 
     val response = getIndividualDetails(individual.nino, IndividualDetail0.fields)
     status(response) shouldBe OK
@@ -30,11 +30,12 @@ class IndividualDetailsControllerISpec extends BaseISpec {
 
     val individualDetails = IndividualDetails(
       dateOfBirth = dateOfBirth.some,
+      crnIndicator = none,
       nameList = nameList.some
     )
 
     val individual = genIndividualInRequest(individualDetails.some)
-    status(postIndividual(individual)) shouldBe OK
+    status(postIndividual(individual)) shouldBe CREATED
 
     val response = getIndividualDetails(individual.nino, IndividualDetail1.fields)
     status(response) shouldBe OK

--- a/it/uk/gov/hmrc/breathingspaceifstub/controller/PeriodsControllerISpec.scala
+++ b/it/uk/gov/hmrc/breathingspaceifstub/controller/PeriodsControllerISpec.scala
@@ -11,7 +11,7 @@ class PeriodsControllerISpec extends BaseISpec {
 
   test("\"get\" Periods should return all periods for an existing Nino, if any") {
     val individual = genIndividualInRequest()
-    status(postIndividual(individual)) shouldBe OK
+    status(postIndividual(individual)) shouldBe CREATED
 
     val postPeriod1 = genPostPeriodInRequest(withEndDate)
     val postPeriod2 = genPostPeriodInRequest(noEndDate)
@@ -32,7 +32,7 @@ class PeriodsControllerISpec extends BaseISpec {
 
   test("\"get\" Periods should return an empty list if no one is found for the provided Nino") {
     val individual = genIndividualInRequest()
-    status(postIndividual(individual)) shouldBe OK
+    status(postIndividual(individual)) shouldBe CREATED
 
     val response = getPeriods(individual.nino)
     status(response) shouldBe OK
@@ -45,7 +45,7 @@ class PeriodsControllerISpec extends BaseISpec {
 
   test("\"post\" Periods should successfully add a single period for the provided Nino") {
     val individual = genIndividualInRequest()
-    status(postIndividual(individual)) shouldBe OK
+    status(postIndividual(individual)) shouldBe CREATED
 
     val postPeriodsInRequest = List(genPostPeriodInRequest(withEndDate))
     status(postPeriods(individual.nino, postPeriodsInRequest)) shouldBe CREATED
@@ -53,7 +53,7 @@ class PeriodsControllerISpec extends BaseISpec {
 
   test("\"post\" Periods should successfully add multiple periods for the provided Nino") {
     val individual = genIndividualInRequest()
-    status(postIndividual(individual)) shouldBe OK
+    status(postIndividual(individual)) shouldBe CREATED
 
     val postPeriodsInRequest = List(
       genPostPeriodInRequest(withEndDate),
@@ -64,7 +64,7 @@ class PeriodsControllerISpec extends BaseISpec {
 
   test("Multiple \"post\" Periods ops to the same Nino should append all provided periods") {
     val individual = genIndividualInRequest()
-    status(postIndividual(individual)) shouldBe OK
+    status(postIndividual(individual)) shouldBe CREATED
 
     val postPeriodsInRequest1 = List(genPostPeriodInRequest(noEndDate))
     status(postPeriods(individual.nino, postPeriodsInRequest1)) shouldBe CREATED
@@ -81,7 +81,7 @@ class PeriodsControllerISpec extends BaseISpec {
 
   test("\"post\" Periods should report if the provided Nino is unknown") {
     val individual = genIndividualInRequest()
-    status(postIndividual(individual)) shouldBe OK
+    status(postIndividual(individual)) shouldBe CREATED
 
     val postPeriodsInRequest = List(genPostPeriodInRequest(withEndDate))
     status(postPeriods(genNino, postPeriodsInRequest)) shouldBe NOT_FOUND


### PR DESCRIPTION
- Fix filter matching for Individual details
- update the expected Http response's status code for a few test support endpoints
  `delete(nino) -> NO_CONTENT`
  `exists(nino) -> {"exists":true}`
  `postIndividual -> CREATED`
  `putIndividual -> NO_CONTENT`