### PR TITLE
[BS-410][LB] Fix for build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,8 @@ lazy val microservice = Project(appName, file("."))
 
 scalastyleConfig := baseDirectory.value / "project" / "scalastyle-config.xml"
 
+unmanagedResourceDirectories in Compile += baseDirectory.value / "public"
+
 unmanagedResourceDirectories in IntegrationTest += baseDirectory.value / "it" / "resources"
 
 lazy val scoverageSettings: Seq[Setting[_]] = Seq(


### PR DESCRIPTION
Fix build.sbt in order to add the "public" folder to the artifact produced