### PR TITLE
[BS-415][LB] Fix payload for errors raised in test endpoints

### DIFF
--- a/app/uk/gov/hmrc/breathingspaceifstub/config/ErrorHandler.scala
+++ b/app/uk/gov/hmrc/breathingspaceifstub/config/ErrorHandler.scala
@@ -61,7 +61,7 @@ class ErrorHandler @Inject()(
     Json.arr(
       Json.obj(
         "code" -> httpErrorCodes.getOrElse[String](statusCode, "SERVER_ERROR"),
-        "message" -> message
+        "reason" -> message
       )
     )
 

--- a/app/uk/gov/hmrc/breathingspaceifstub/controller/IndividualDetailsController.scala
+++ b/app/uk/gov/hmrc/breathingspaceifstub/controller/IndividualDetailsController.scala
@@ -43,7 +43,7 @@ class IndividualDetailsController @Inject()(
         .getIndividualDetails(nino)
         .map(
           _.fold(
-            logAndGenErrorResult,
+            logAndGenFailureResult,
             individualDetails =>
               Ok(Json.obj("nino" -> Json.toJson(nino)) ++ Json.toJson(individualDetails).as[JsObject])
           )
@@ -54,17 +54,17 @@ class IndividualDetailsController @Inject()(
           implicit val requestId = RequestId(BS_Detail0_GET)
           individualDetailsService
             .getIndividualDetail0(nino)
-            .map(_.fold(logAndGenErrorResult, individualDetail0 => Ok(Json.toJson(individualDetail0))))
+            .map(_.fold(logAndGenFailureResult, individualDetail0 => Ok(Json.toJson(individualDetail0))))
 
         case IndividualDetail1.fields =>
           implicit val requestId = RequestId(BS_Detail1_GET)
           individualDetailsService
             .getIndividualDetail1(nino)
-            .map(_.fold(logAndGenErrorResult, individualDetail1 => Ok(Json.toJson(individualDetail1))))
+            .map(_.fold(logAndGenFailureResult, individualDetail1 => Ok(Json.toJson(individualDetail1))))
 
         case _ =>
           implicit val requestId = RequestId(BS_Detail_GET)
-          logAndGenHttpError(Failure(UNKNOWN_DATA_ITEM)).send
+          logAndSendFailureResult(Failure(UNKNOWN_DATA_ITEM))
       }
     }
   }

--- a/app/uk/gov/hmrc/breathingspaceifstub/controller/PeriodsController.scala
+++ b/app/uk/gov/hmrc/breathingspaceifstub/controller/PeriodsController.scala
@@ -36,17 +36,17 @@ class PeriodsController @Inject()(periodsService: PeriodsService, cc: Controller
     implicit val requestId = RequestId(BS_Detail0_GET)
     periodsService
       .get(nino)
-      .map(_.fold(logAndGenErrorResult, periods => Ok(Json.toJson(periods))))
+      .map(_.fold(logAndGenFailureResult, periods => Ok(Json.toJson(periods))))
   }
 
   def post(nino: String): Action[Response[PostPeriodsInRequest]] =
     Action.async(withJsonBody[PostPeriodsInRequest]) { implicit request =>
       implicit val requestId = RequestId(BS_Periods_POST)
       request.body.fold(
-        logAndSendErrorResult,
+        logAndSendFailureResult,
         periodsService
           .post(nino, _)
-          .map(_.fold(logAndGenErrorResult, periods => Created(Json.toJson(periods))))
+          .map(_.fold(logAndGenFailureResult, periods => Created(Json.toJson(periods))))
       )
     }
 }

--- a/app/uk/gov/hmrc/breathingspaceifstub/model/Failure.scala
+++ b/app/uk/gov/hmrc/breathingspaceifstub/model/Failure.scala
@@ -70,4 +70,12 @@ object Failure {
         "reason" -> failure.baseError.message
       )
   }
+
+  val asErrorItem = new Writes[Failure] {
+    def writes(failure: Failure): JsObject =
+      Json.obj(
+        "code" -> failure.baseError.entryName,
+        "message" -> failure.baseError.message
+      )
+  }
 }

--- a/app/uk/gov/hmrc/breathingspaceifstub/model/HttpError.scala
+++ b/app/uk/gov/hmrc/breathingspaceifstub/model/HttpError.scala
@@ -37,6 +37,12 @@ object HttpError extends Logging {
     apply(correlationId.toString.some, if (httpCode == 0) failure.baseError.httpCode else httpCode, payload)
   }
 
+  def asErrorItem(correlationId: => Option[String], failure: Failure, httpCode: Int = 0): HttpError = {
+    implicit val writes = Failure.asErrorItem
+    val payload = Json.obj("errors" -> List(failure))
+    apply(correlationId.toString.some, if (httpCode == 0) failure.baseError.httpCode else httpCode, payload)
+  }
+
   def apply(correlationId: Option[String], httpCode: Int, payload: JsObject): HttpError = {
     val headers = List(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
     new HttpError(

--- a/app/uk/gov/hmrc/breathingspaceifstub/model/NinoValidation.scala
+++ b/app/uk/gov/hmrc/breathingspaceifstub/model/NinoValidation.scala
@@ -29,13 +29,13 @@ trait NinoValidation {
   def isValid(nino: String): Boolean = nino.matches(validNinoFormat)
 
   def stripNinoSuffixAndExecOp[T](nino: String, f: String => AsyncResponse[T]): AsyncResponse[T] =
-    if (!isValid(nino)) Future.successful(Left(Failure(INVALID_NINO)))
-    else
+    if (isValid(nino)) {
       nino.length match {
         case 8 => f(nino)
         case 9 => f(nino.substring(0, 8))
         case _ => Future.successful(Left(Failure(INVALID_NINO)))
       }
+    } else Future.successful(Left(Failure(INVALID_NINO)))
 
   lazy val valid1stChars = ('A' to 'Z').filterNot(List('D', 'F', 'I', 'Q', 'U', 'V').contains).map(_.toString)
   lazy val valid2ndChars = ('A' to 'Z').filterNot(List('D', 'F', 'I', 'O', 'Q', 'U', 'V').contains).map(_.toString)

--- a/it/uk/gov/hmrc/breathingspaceifstub/controller/IndividualControllerISpec.scala
+++ b/it/uk/gov/hmrc/breathingspaceifstub/controller/IndividualControllerISpec.scala
@@ -96,7 +96,7 @@ class IndividualControllerISpec extends BaseISpec {
 
     val response = postIndividual(individual)
     status(response) shouldBe CONFLICT
-    assert(contentAsString(response).startsWith(s"""{"failures":[{"code":"${CONFLICTING_REQUEST.entryName}"""))
+    assert(contentAsString(response).startsWith(s"""{"errors":[{"code":"${CONFLICTING_REQUEST.entryName}"""))
   }
 
   test("\"postIndividuals\" should successfully add all given new documents to the \"individual\" collection") {
@@ -124,7 +124,7 @@ class IndividualControllerISpec extends BaseISpec {
     val individual2 = IndividualInRequest(genNinoWithSuffix, none)
     val response = postIndividuals(IndividualsInRequest(List(individual1, individual2, individual1)))
     status(response) shouldBe BAD_REQUEST
-    (contentAsJson(response) \ "failures" \\ "code").head.as[String] shouldBe "INVALID_NINO"
+    (contentAsJson(response) \ "errors" \\ "code").head.as[String] shouldBe "INVALID_NINO"
   }
 
   test("\"replaceIndividualDetails\" should successfully replace the individual details for the given Nino") {


### PR DESCRIPTION
- Payload for production endpoints should be: {"failures":[{"code":"..", "reason": ".."}]}
- Payload for test-support endpoints should be: {"errors":[{"code":"..", "message": ".."}]}